### PR TITLE
change command separator to &&

### DIFF
--- a/bin/sra.js
+++ b/bin/sra.js
@@ -26,7 +26,7 @@ const getDeps = deps => Object.entries(deps).map(dep =>
     .replace(/fs-extra[^\s]+/g, '');
 
 console.log('Initializing project..');
-exec(`mkdir ${process.argv[2]} ; cd ${process.argv[2]} ; npm init -f`, (initErr, initStdout, initStderr) => {
+exec(`mkdir ${process.argv[2]} && cd ${process.argv[2]} && npm init -f`, (initErr, initStdout, initStderr) => {
   if (initErr) {
     console.error(`Everything was fine, then it wasn't:
     ${initErr}`);
@@ -53,7 +53,7 @@ exec(`mkdir ${process.argv[2]} ; cd ${process.argv[2]} ; npm init -f`, (initErr,
   console.log('Installing deps -- it might take a few minutes..');
   const devDeps = getDeps(packageJson.devDependencies);
   const deps = getDeps(packageJson.dependencies);
-  exec(`cd ${process.argv[2]} ; npm i -D ${devDeps} ; npm i -S ${deps}`,
+  exec(`cd ${process.argv[2]} && npm i -D ${devDeps} && npm i -S ${deps}`,
   (npmErr, npmStdout, npmStderr) => {
     if (npmErr) {
       console.error(`it's always npm, ain't it?


### PR DESCRIPTION
@Kornil I tried to use your script on Windows (using cmder), but the way commands are chained is differently on Windows and it would fail (it actually takes everything as an argument to mkdir and creates a bunch of folders). I changed the separator (not sure if that is how you would call it) to `&&`. This should work on all platforms and it also has the benefit that it only runs the next command if the previous one was successful.
I don't have access to a Mac or Linux machine, so I was not able to try it out myself.