### PR TITLE
ensure scripts work on different platforms

### DIFF
--- a/bin/sra.js
+++ b/bin/sra.js
@@ -7,8 +7,8 @@ const { exec } = require('child_process');
 const packageJson = require('../package.json');
 
 const scripts =
-  `"start": "NODE_ENV=development webpack-dev-server",
-  "build": "NODE_ENV=production webpack -p"`;
+  `"start": "cross-env NODE_ENV=development webpack-dev-server",
+  "build": "cross-env NODE_ENV=production webpack -p"`;
 
 /**
  * we pass the object key dependency || devdependency to this function


### PR DESCRIPTION
@Kornil another PR to make it windows compatible :-) 
Added cross-env to the scripts, otherwise it doesn't work on Windows, cross-env is already part of the package.json, so I didn't even have to add a new dependency.