### PR TITLE
Fix cannot GET /route on refresh

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -33,6 +33,7 @@ module.exports = {
     headers: {
       'Access-Control-Allow-Origin': '*',
     },
+    historyApiFallback: true,
   },
   entry: [
     'react-hot-loader/patch',
@@ -64,6 +65,7 @@ module.exports = {
   output: {
     filename: 'index.js',
     path: path.join(__dirname, '/build'),
+    publicPath: '/',
   },
   plugins: dev ?
   [


### PR DESCRIPTION
To reproduce this: Start a project with simple-react-app, "yarn start" or "npm run start," & point your browser to localhost: 3000.

Navigate to /about.

Refresh the browser. 

I get "Cannot GET /about."

This PR tells Webpack Dev Server to redirect all server requests to /index.html so it can handle the route on refresh.