### PR TITLE
fix the error for Link to="/"

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -6,5 +6,10 @@
     "es6": true,
     "mocha": true
   },
-  "rules": {}
+  "rules": {
+    "jsx-a11y/anchor-is-valid": [ "error", {
+      "components": [ "Link" ],
+      "specialLink": [ "to" ]
+    }]
+  }
 }


### PR DESCRIPTION
removing `The href attribute is required on an anchor. Provide a valid, navigable address as the href value. (jsx-a11y/anchor-is-valid)`
error