### PR TITLE
I had to remove these commas to get this to work on ubuntu 16.04

### DIFF
--- a/bin/sra.js
+++ b/bin/sra.js
@@ -94,7 +94,7 @@ exec(
             if (err) throw err;
           });
         });
-      },
+      }
     );
 
     console.log('npm init -- done\n');
@@ -123,7 +123,7 @@ exec(
               process.argv[2]
             } folder, refer to the README for the project structure.\nHappy Coding!`))
           .catch(err => console.error(err));
-      },
+      }
     );
-  },
+  }
 );


### PR DESCRIPTION
I simply removed these delineating commas in order to get simple-react-app to work on Ubuntu 16.04.
I know that they are there in case you want to add more to the https.get function, but I had to remove them to get functionality.